### PR TITLE
Allow for alerts to fire from any user.

### DIFF
--- a/message_darwin.go
+++ b/message_darwin.go
@@ -58,7 +58,7 @@ func osaDialog(title, text, icon string) (bool, error) {
 		return false, err
 	}
 
-	out, err := exec.Command(osa, "-e", `set T to button returned of (display dialog "`+text+`" with title "`+title+`" buttons {"OK"} default button "OK" with icon `+icon+`)`).Output()
+	out, err := exec.Command(osa, "-e", `tell application "System Events" to display dialog "`+text+`" with title "`+title+`" buttons {"OK"} default button "OK" with icon `+icon+``).Output()
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)


### PR DESCRIPTION
While using this library to fire alerts for a golang app (more specifically an osquery plugin) which runs as root, alerts wouldn't fire as root had no logged in session. Setting the osascript to `tell application "System Events"` made the alert popup on the currently logged in users screen.