### PR TITLE
Fixed a bug in Darwin 

### DIFF
--- a/file_darwin.go
+++ b/file_darwin.go
@@ -4,6 +4,7 @@ package dlgs
 
 import (
 	"os/exec"
+	"path"
 	"strings"
 	"syscall"
 )
@@ -40,7 +41,7 @@ func File(title, filter string, directory bool) (string, bool, error) {
 	}
 
 	tmp := strings.Split(out, ":")
-	outPath := "/" + strings.Join(tmp[1:len(tmp)-1], "/")
+	outPath := "/" + path.Join(tmp[1:]...)
 
 	return outPath, ret, err
 }
@@ -76,7 +77,7 @@ func FileMulti(title, filter string) ([]string, bool, error) {
 	l := strings.Split(out, ", ")
 	for _, p := range l {
 		tmp := strings.Split(p, ":")
-		paths = append(paths, "/"+strings.Join(tmp[1:], "/"))
+		paths = append(paths, "/"+path.Join(tmp[1:]...))
 	}
 
 	return paths, ret, err


### PR DESCRIPTION
The bug: if path of **file** was chosen, the last element (i.e. the file itself) would be dropped. 

These are the raw outputs of the `osascript choose...` command:

```
$ osascript -e 'choose file'
alias Macintosh HD:Users:chewxy:workspace:gorgoniaws:src:stuff:cmd:train:checkpoint.0

$  osascript -e 'choose folder'
alias Macintosh HD:Users:chewxy:workspace:gorgoniaws:src:stuff:cmd:train:images:
```

Observe that when `"choose folder"`.  is used as the script, there is a trailing `:`, but when `"choose file"` is used, there are no trailing `:` 

Hence it can be deduced that the reason for dropping the last element is because the function wishes to handle directories. 

Upon further investigation, it's noted that `strings.Join` was used. This is not recommended practice. Instead, the proper path handling library, which is built into the stdlib of Go should be used.

Thus, the functions have been amended to use the proper path library.