### PR TITLE
Fixed problem to display dialogs on MacOs Catalina

### DIFF
--- a/message_darwin.go
+++ b/message_darwin.go
@@ -58,7 +58,7 @@ func osaDialog(title, text, icon string) (bool, error) {
 		return false, err
 	}
 
-	out, err := exec.Command(osa, "-e", `tell application "System Events" to display dialog "`+text+`" with title "`+title+`" buttons {"OK"} default button "OK" with icon `+icon+``).Output()
+	out, err := exec.Command(osa, "-e", `display dialog "`+text+`" with title "`+title+`" buttons {"OK"} default button "OK" with icon `+icon+``).Output()
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)


### PR DESCRIPTION
When trying to open an Error dialog on MacOs Catalina, I was getting the error "Cannot convert application "System Events" in type number or string. (-1700)".

Removing the "tell application "System Events" to" it worked for me.