### PR TITLE
Fix build error on darwin

### DIFF
--- a/file_darwin.go
+++ b/file_darwin.go
@@ -96,5 +96,5 @@ func FileMulti(title, filter string) ([]string, bool, error) {
 		paths = append(paths, "/"+path.Join(tmp[1:]...))
 	}
 
-	return paths, ret, err
+	return paths, true, err
 }


### PR DESCRIPTION
Build on darwin fails due to missing the change in #22.

```sh
$ sw_vers
ProductName:    macOS
ProductVersion: 11.2.1
BuildVersion:   20D74

$ go build ./...
./file_darwin.go:99:16: undefined: ret
```

This PR fix the build error and now I confirmed that the build will pass.