### PR TITLE
fix dirDialog: incorrect result if path too short

### DIFF
--- a/file_windows.go
+++ b/file_windows.go
@@ -10,8 +10,8 @@ import (
 )
 
 // File displays a file dialog, returning the selected file or directory, a bool for success, and an
-// error if it was unable to display the dialog. Filter is a string that determines 
-// which extensions should be displayed for the dialog. Separate multiple file 
+// error if it was unable to display the dialog. Filter is a string that determines
+// which extensions should be displayed for the dialog. Separate multiple file
 // extensions by spaces and use "*.extension" format for cross-platform compatibility, e.g. "*.png *.jpg".
 // A blank string for the filter will display all file types.
 func File(title, filter string, directory bool) (string, bool, error) {
@@ -24,9 +24,9 @@ func File(title, filter string, directory bool) (string, bool, error) {
 	return out, ok, nil
 }
 
-// FileMulti displays a file dialog that allows for selecting multiple files. It returns the selected 
-// files, a bool for success, and an error if it was unable to display the dialog. Filter is a string 
-// that determines which files should be available for selection in the dialog. Separate multiple file 
+// FileMulti displays a file dialog that allows for selecting multiple files. It returns the selected
+// files, a bool for success, and an error if it was unable to display the dialog. Filter is a string
+// that determines which files should be available for selection in the dialog. Separate multiple file
 // extensions by spaces and use "*.extension" format for cross-platform compatibility, e.g. "*.png *.jpg".
 // A blank string for the filter will display all file types.
 func FileMulti(title, filter string) ([]string, bool, error) {
@@ -87,13 +87,12 @@ func dirDialog(title string) (string, bool) {
 	t, _ := syscall.UTF16PtrFromString(title)
 
 	bi.title = t
-	bi.displayName = &buf[0]
 	bi.flags = bifEditBox | bifNewDialogStyle
 
 	lpItem := shBrowseForFolder(&bi)
 	ok := shGetPathFromIDList(lpItem, &buf[0])
 	if ok {
-		return stringFromUtf16Ptr(bi.displayName), true
+		return stringFromUtf16Ptr(&buf[0]), true
 	}
 
 	return "", false


### PR DESCRIPTION
This pull request is related to issue #20 .

Platform: Windows 10
Summary: if a user selects the root of a disk / USB device (file picker), then the returned file path is incorrect. Example: user selects the root of disk C `C:\` but the return value is `C:\l Disk (C:)`. This bug seems to be related to the length of the file path which the user had selected. If the user selects a child directory (not the root of a disk/device), then the correct file path is returned. I tested this change on Windows 10 64 Bit.

For an explanation please read the comment by @ncruces: https://github.com/gen2brain/dlgs/issues/20#issuecomment-813522377