### PR TITLE
Fix Darwin implementation to escape input sent to osascript

### DIFF
--- a/color_darwin.go
+++ b/color_darwin.go
@@ -13,11 +13,6 @@ import (
 
 // Color displays a color selection dialog, returning the selected color and a bool for success.
 func Color(title, defaultColorHex string) (color.Color, bool, error) {
-	osa, err := exec.LookPath("osascript")
-	if err != nil {
-		return nil, false, err
-	}
-
 	var ur, ug, ub uint8
 	fmt.Sscanf(defaultColorHex, "#%02x%02x%02x", &ur, &ug, &ub)
 
@@ -25,7 +20,7 @@ func Color(title, defaultColorHex string) (color.Color, bool, error) {
 	g := strconv.Itoa(int(ug))
 	b := strconv.Itoa(int(ub))
 
-	o, err := exec.Command(osa, "-e", `tell application "Finder"`, "-e", "activate", "-e", `choose color default color {`+r+`, `+g+`, `+b+`}`, "-e", "end tell").Output()
+	o, err := osaExecute(`tell application "Finder"`, `activate`, `choose color default color {`+r+`, `+g+`, `+b+`}`, `end tell`)
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)
@@ -33,8 +28,7 @@ func Color(title, defaultColorHex string) (color.Color, bool, error) {
 		}
 	}
 
-	out := strings.TrimSpace(string(o))
-
+	out := strings.TrimSpace(o)
 	return parseColor(out), true, err
 }
 

--- a/date_darwin.go
+++ b/date_darwin.go
@@ -12,13 +12,8 @@ import (
 
 // Date displays a calendar dialog, returning the date and a bool for success.
 func Date(title, text string, defaultDate time.Time) (time.Time, bool, error) {
-	osa, err := exec.LookPath("osascript")
-	if err != nil {
-		return time.Now(), false, err
-	}
-
-	o, err := exec.Command(osa, "-e", `set defaultDate to do shell script "date -j -r `+strconv.Itoa(int(defaultDate.Unix()))+` +%m/%d/%Y"`,
-		"-e", `set T to text returned of (display dialog "`+text+` (mm/dd/yyyy)" with title "`+title+`" default answer defaultDate)`).Output()
+	o, err := osaExecute(`set defaultDate to do shell script "date -j -r `+strconv.Itoa(int(defaultDate.Unix()))+` +%m/%d/%Y"`,
+		`set T to text returned of (display dialog `+osaEscapeString(text+` (mm/dd/yyyy)`)+` with title `+osaEscapeString(title)+` default answer defaultDate)`)
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)
@@ -27,7 +22,7 @@ func Date(title, text string, defaultDate time.Time) (time.Time, bool, error) {
 	}
 
 	ret := true
-	out := strings.TrimSpace(string(o))
+	out := strings.TrimSpace(o)
 	if out == "" {
 		ret = false
 	}

--- a/dlgs_darwin.go
+++ b/dlgs_darwin.go
@@ -1,0 +1,27 @@
+// +build darwin,!linux,!windows,!js
+
+package dlgs
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// osaEscape escapes a string to be used in AppleScript
+func osaEscapeString(unescaped string) string {
+	escaped := strings.ReplaceAll(unescaped, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "\"", "\\\"")
+	escaped = strings.ReplaceAll(escaped, "\n", "\\\n")
+	return `"` + escaped + `"`
+}
+
+// osaExecute executes AppleScript
+func osaExecute(command ...string) (string, error) {
+	osa, err := exec.LookPath("osascript")
+	if err != nil {
+		return "", err
+	}
+
+	out, err := exec.Command(osa, "-e", strings.Join(command, "\n")).Output()
+	return string(out), err
+}

--- a/entry_darwin.go
+++ b/entry_darwin.go
@@ -10,12 +10,7 @@ import (
 
 // Entry displays input dialog, returning the entered value and a bool for success.
 func Entry(title, text, defaultText string) (string, bool, error) {
-	osa, err := exec.LookPath("osascript")
-	if err != nil {
-		return "", false, err
-	}
-
-	o, err := exec.Command(osa, "-e", `set T to text returned of (display dialog "`+text+`" with title "`+title+`" default answer "`+defaultText+`")`).Output()
+	o, err := osaExecute(`set T to text returned of (display dialog ` + osaEscapeString(text) + ` with title ` + osaEscapeString(title) + ` default answer ` + osaEscapeString(defaultText) + `)`)
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)
@@ -23,7 +18,7 @@ func Entry(title, text, defaultText string) (string, bool, error) {
 		}
 	}
 
-	out := strings.TrimSpace(string(o))
+	out := strings.TrimSpace(o)
 
 	return out, true, err
 }

--- a/list_darwin.go
+++ b/list_darwin.go
@@ -10,20 +10,15 @@ import (
 
 // List displays a list dialog, returning the selected value and a bool for success.
 func List(title, text string, items []string) (string, bool, error) {
-	osa, err := exec.LookPath("osascript")
-	if err != nil {
-		return "", false, err
-	}
-
 	list := ""
 	for i, l := range items {
-		list += `"` + l + `"`
+		list += osaEscapeString(l)
 		if i != len(items)-1 {
 			list += ", "
 		}
 	}
 
-	o, err := exec.Command(osa, "-e", `choose from list {`+list+`} with prompt "`+text+`" with title "`+title+`"`).Output()
+	o, err := osaExecute(`choose from list {` + list + `} with prompt ` + osaEscapeString(text) + ` with title ` + osaEscapeString(title))
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)
@@ -31,27 +26,22 @@ func List(title, text string, items []string) (string, bool, error) {
 		}
 	}
 
-	out := strings.TrimSpace(string(o))
+	out := strings.TrimSpace(o)
 
 	return out, true, err
 }
 
 // ListMulti displays a multiple list dialog, returning the selected values and a bool for success.
 func ListMulti(title, text string, items []string) ([]string, bool, error) {
-	osa, err := exec.LookPath("osascript")
-	if err != nil {
-		return []string{}, false, err
-	}
-
 	list := ""
 	for i, l := range items {
-		list += `"` + l + `"`
+		list += osaEscapeString(l)
 		if i != len(items)-1 {
 			list += ", "
 		}
 	}
 
-	o, err := exec.Command(osa, "-e", `choose from list {`+list+`} with multiple selections allowed with prompt "`+text+`" with title "`+title+`"`).Output()
+	o, err := osaExecute(`choose from list {` + list + `} with multiple selections allowed with prompt ` + osaEscapeString(text) + ` with title ` + osaEscapeString(title))
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)
@@ -59,7 +49,7 @@ func ListMulti(title, text string, items []string) ([]string, bool, error) {
 		}
 	}
 
-	out := strings.TrimSpace(string(o))
+	out := strings.TrimSpace(o)
 
 	return strings.Split(out, ", "), true, err
 }

--- a/message_darwin.go
+++ b/message_darwin.go
@@ -25,17 +25,12 @@ func Error(title, text string) (bool, error) {
 
 // Question displays question dialog.
 func Question(title, text string, defaultCancel bool) (bool, error) {
-	osa, err := exec.LookPath("osascript")
-	if err != nil {
-		return false, err
-	}
-
 	btn := "Yes"
 	if defaultCancel {
 		btn = "No"
 	}
 
-	out, err := exec.Command(osa, "-e", `set T to button returned of (display dialog "`+text+`" with title "`+title+`" buttons {"No", "Yes"} default button "`+btn+`")`).Output()
+	out, err := osaExecute(`set T to button returned of (display dialog ` + osaEscapeString(text) + ` with title ` + osaEscapeString(title) + ` buttons {"No", "Yes"} default button ` + osaEscapeString(btn) + `)`)
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)
@@ -44,7 +39,7 @@ func Question(title, text string, defaultCancel bool) (bool, error) {
 	}
 
 	ret := false
-	if strings.TrimSpace(string(out)) == "Yes" {
+	if strings.TrimSpace(out) == "Yes" {
 		ret = true
 	}
 
@@ -53,12 +48,7 @@ func Question(title, text string, defaultCancel bool) (bool, error) {
 
 // osaDialog displays dialog.
 func osaDialog(title, text, icon string) (bool, error) {
-	osa, err := exec.LookPath("osascript")
-	if err != nil {
-		return false, err
-	}
-
-	out, err := exec.Command(osa, "-e", `display dialog "`+text+`" with title "`+title+`" buttons {"OK"} default button "OK" with icon `+icon+``).Output()
+	out, err := osaExecute(`display dialog ` + osaEscapeString(text) + ` with title ` + osaEscapeString(title) + ` buttons {"OK"} default button "OK" with icon ` + icon + ``)
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)
@@ -67,7 +57,7 @@ func osaDialog(title, text, icon string) (bool, error) {
 	}
 
 	ret := false
-	if strings.TrimSpace(string(out)) == "OK" {
+	if strings.TrimSpace(out) == "OK" {
 		ret = true
 	}
 

--- a/password_darwin.go
+++ b/password_darwin.go
@@ -10,12 +10,7 @@ import (
 
 // Password displays a dialog, returning the entered value and a bool for success.
 func Password(title, text string) (string, bool, error) {
-	osa, err := exec.LookPath("osascript")
-	if err != nil {
-		return "", false, err
-	}
-
-	o, err := exec.Command(osa, "-e", `set T to text returned of (display dialog "`+text+`" with title "`+title+`" default answer "" with hidden answer)`).Output()
+	o, err := osaExecute(`set T to text returned of (display dialog ` + osaEscapeString(text) + ` with title ` + osaEscapeString(title) + ` default answer "" with hidden answer)`)
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)
@@ -23,7 +18,7 @@ func Password(title, text string) (string, bool, error) {
 		}
 	}
 
-	out := strings.TrimSpace(string(o))
+	out := strings.TrimSpace(o)
 
 	return out, true, err
 }


### PR DESCRIPTION
The current MacOS implementation of `dlgs` is vulnerable to code injection through unescaped text being sent to the `osascript` command. This PR fixes this by escaping the text before concatenating it with the AppleScript. 

Demonstration:

```go
Info("Proof of Concept\" buttons {\"OK\"} \n tell application \"Calculator\" to activate \n--", "Hello, Calculator.app!")
//                     ^                     ^- Open Calculator.app                        ^
//                     |- Break out of the title string.                                   |- Comment out the rest of the original AppleScript.
```

This should open the Calculator app.