### PR TITLE
Exclude filtering in file dialog when it's a directory.

### DIFF
--- a/file_darwin.go
+++ b/file_darwin.go
@@ -21,7 +21,7 @@ func File(title, filter string, directory bool) (string, bool, error) {
 	}
 
 	t := ""
-	if filter != "" {
+	if filter != "" && !directory {
 		t = ` of type {`
 		patterns := strings.Split(filter, " ")
 		for i, p := range patterns {

--- a/file_linux.go
+++ b/file_linux.go
@@ -25,7 +25,7 @@ func File(title, filter string, directory bool) (string, bool, error) {
 	}
 
 	fileFilter := ""
-	if filter != "" {
+	if filter != "" && !directory {
 		fileFilter = "--file-filter=" + filter
 	}
 


### PR DESCRIPTION
On macOS this was breaking the file dialog from being launched when using osascript.