### PR TITLE
Implement simple MessageBox dialog, where no icon will be displayed.

### DIFF
--- a/message_darwin.go
+++ b/message_darwin.go
@@ -8,6 +8,11 @@ import (
 	"syscall"
 )
 
+// MessageBox displays message box and ok button without icon.
+func MessageBox(title, text string) (bool, error) {
+	return osaDialog(title, text, "")
+}
+
 // Info displays information dialog.
 func Info(title, text string) (bool, error) {
 	return osaDialog(title, text, "note")
@@ -48,7 +53,11 @@ func Question(title, text string, defaultCancel bool) (bool, error) {
 
 // osaDialog displays dialog.
 func osaDialog(title, text, icon string) (bool, error) {
-	out, err := osaExecute(`display dialog ` + osaEscapeString(text) + ` with title ` + osaEscapeString(title) + ` buttons {"OK"} default button "OK" with icon ` + icon + ``)
+	iconScript := ""
+	if icon != "" {
+		iconScript = ` with icon ` + icon
+	}
+	out, err := osaExecute(`display dialog ` + osaEscapeString(text) + ` with title ` + osaEscapeString(title) + ` buttons {"OK"} default button "OK"` + iconScript)
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			ws := exitError.Sys().(syscall.WaitStatus)

--- a/message_js.go
+++ b/message_js.go
@@ -6,6 +6,11 @@ import (
 	"github.com/gopherjs/gopherjs/js"
 )
 
+// MessageBox displays message box and ok button without icon.
+func MessageBox(title, text string) (bool, error) {
+	return alertDialog(title, text, "")
+}
+
 // Info displays information dialog.
 func Info(title, text string) (ret bool, err error) {
 	return alertDialog(title, text, "\u24d8")

--- a/message_linux.go
+++ b/message_linux.go
@@ -7,6 +7,11 @@ import (
 	"syscall"
 )
 
+// MessageBox displays message box and ok button without icon.
+func MessageBox(title, text string) (bool, error) {
+	return cmdDialog(title, text, "info") // TODO: Remove icon
+}
+
 // Info displays information dialog.
 func Info(title, text string) (bool, error) {
 	return cmdDialog(title, text, "info")

--- a/message_test.go
+++ b/message_test.go
@@ -4,6 +4,17 @@ import (
 	"testing"
 )
 
+func TestMessageBox(t *testing.T) {
+	ret, err := MessageBox("MessageBox", "Lorem ipsum dolor sit amet.")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if verboseTests {
+		println("ret:", ret)
+	}
+}
+
 func TestInfo(t *testing.T) {
 	ret, err := Info("Info", "Lorem ipsum dolor sit amet.")
 	if err != nil {

--- a/message_unsupported.go
+++ b/message_unsupported.go
@@ -2,6 +2,11 @@
 
 package dlgs
 
+// MessageBox displays message box and ok button without icon.
+func MessageBox(title, text string) (bool, error) {
+	return false, ErrUnsupported
+}
+
 // Info displays information dialog box.
 func Info(title, message string) (bool, error) {
 	return false, ErrUnsupported

--- a/message_windows.go
+++ b/message_windows.go
@@ -2,6 +2,12 @@
 
 package dlgs
 
+// MessageBox displays message box and ok button without icon.
+func MessageBox(title, text string) (bool, error) {
+	ret := messageBox(title, text, mbOk)
+	return ret == idOk, nil
+}
+
 // Info displays information dialog.
 func Info(title, text string) (bool, error) {
 	ret := messageBox(title, text, mbOk|mbIconInfo)


### PR DESCRIPTION
In some cases it was necessary to have a dialog without the icon. Especially on macOS where the dialog's text gets squeezed due to the icon being too big, making it look a little odd.
On Linux I made it display as `info`, since I don't know of a way to disable icons using zenity.